### PR TITLE
add no-timeout support to runner

### DIFF
--- a/Jenkins.NET/Properties/AssemblyInfo.cs
+++ b/Jenkins.NET/Properties/AssemblyInfo.cs
@@ -2,8 +2,8 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.1.5")]
-[assembly: AssemblyFileVersion("0.1.5")]
+[assembly: AssemblyVersion("0.1.7")]
+[assembly: AssemblyFileVersion("0.1.7")]
 [assembly: AssemblyTitle("Jenkins.NET")]
 [assembly: AssemblyDescription("C# .NET wrapper for Jenkins HTTP/REST API.")]
 [assembly: AssemblyConfiguration("")]


### PR DESCRIPTION
Add support for disabling Queue and Build timeouts.
- Changed default queue timeout from 30 seconds to 60 seconds (1 minute).
- Changed default build timeout from 60 seconds to 600 seconds (10 minutes).
- Either can be disabled by setting to a value <= 0.