### PR TITLE
Client interface

### DIFF
--- a/Jenkins.Net/IJenkinsClient.cs
+++ b/Jenkins.Net/IJenkinsClient.cs
@@ -1,0 +1,60 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JenkinsNET.Models;
+
+namespace JenkinsNET
+{
+    /// <summary>
+    /// Methods for interacting with Jenkins API.
+    /// </summary>
+    public interface IJenkinsClient
+    {
+        /// <summary>
+        /// Group of methods for interacting with Jenkins Jobs.
+        /// </summary>
+        JenkinsClientJobs Jobs {get;}
+
+        /// <summary>
+        /// Group of methods for interacting with Jenkins Builds.
+        /// </summary>
+        JenkinsClientBuilds Builds {get;}
+
+        /// <summary>
+        /// Group of methods for interacting with the Jenkins Job-Queue.
+        /// </summary>
+        JenkinsClientQueue Queue {get;}
+
+        /// <summary>
+        /// Group of methods for interacting with Jenkins Artifacts.
+        /// </summary>
+        JenkinsClientArtifacts Artifacts {get;}
+
+        /// <summary>
+        /// Updates the security Crumb attached to this client.
+        /// </summary>
+        /// <exception cref="JenkinsNetException"></exception>
+        void UpdateSecurityCrumb();
+
+
+        /// <summary>
+        /// Updates the security Crumb attached to this client asynchronously.
+        /// </summary>
+        /// <param name="token">An optional token for aborting the request.</param>
+        /// <exception cref="JenkinsNetException"></exception>
+        Task UpdateSecurityCrumbAsync(CancellationToken token = default(CancellationToken));
+
+        /// <summary>
+        /// Gets the root description of the Jenkins node.
+        /// </summary>
+        /// <exception cref="JenkinsNetException"></exception>
+        Jenkins Get();
+
+
+        /// <summary>
+        /// Gets the root description of the Jenkins node asynchronously.
+        /// </summary>
+        /// <param name="token">An optional token for aborting the request.</param>
+        /// <exception cref="JenkinsNetException"></exception>
+        Task<Jenkins> GetAsync(CancellationToken token = default(CancellationToken));
+    }
+}

--- a/Jenkins.Net/IJenkinsContext.cs
+++ b/Jenkins.Net/IJenkinsContext.cs
@@ -1,4 +1,5 @@
-﻿using JenkinsNET.Models;
+﻿using System;
+using JenkinsNET.Models;
 
 namespace JenkinsNET
 {
@@ -21,7 +22,13 @@ namespace JenkinsNET
         /// <summary>
         /// [optional] Jenkins Password.
         /// </summary>
+        [Obsolete("This property will be removed in future versions; please use 'JenkinsContext.ApiToken' instead.")]
         string Password {get;}
+
+        /// <summary>
+        /// [optional] Jenkins ApiToken for the <see cref="UserName"/>.
+        /// </summary>
+        string ApiToken {get; set;}
 
         /// <summary>
         /// [optional] Jenkins CSRF Crumb.

--- a/Jenkins.Net/JenkinsClient.cs
+++ b/Jenkins.Net/JenkinsClient.cs
@@ -10,7 +10,7 @@ namespace JenkinsNET
     /// <summary>
     /// HTTP-Client for interacting with Jenkins API.
     /// </summary>
-    public class JenkinsClient : IJenkinsContext
+    public class JenkinsClient : IJenkinsContext, IJenkinsClient
     {
         /// <summary>
         /// The address of the Jenkins instance.

--- a/Jenkins.Net/JenkinsClient.cs
+++ b/Jenkins.Net/JenkinsClient.cs
@@ -83,6 +83,17 @@ namespace JenkinsNET
         }
 
         /// <summary>
+        /// Creates a new Jenkins Client using the provided <see cref="IJenkinsContext"/>.
+        /// </summary>
+        public JenkinsClient(IJenkinsContext context) : this(context.BaseUrl)
+        {
+            this.UserName = context.UserName;
+            this.ApiToken = context.ApiToken;
+            this.Password = context.Password;
+            this.Crumb = context.Crumb;
+        }
+
+        /// <summary>
         /// Updates the security Crumb attached to this client.
         /// </summary>
         /// <exception cref="JenkinsNetException"></exception>


### PR DESCRIPTION
Create an interface so that the JenkinsClient can be:
1. Mocked in unit tests
2. Used with dependency injection

Added ApiToken to `IJenkinsContext`.
Allow `JenkinsClient` to be instantiated with a `IJenkinsContext`.

