### PR TITLE
Introduce 'ExtraHeaders' capability across all Commands

### DIFF
--- a/Jenkins.Net/IJenkinsContext.cs
+++ b/Jenkins.Net/IJenkinsContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using JenkinsNET.Models;
 
 namespace JenkinsNET
@@ -29,6 +30,11 @@ namespace JenkinsNET
         /// [optional] Jenkins ApiToken for the <see cref="UserName"/>.
         /// </summary>
         string ApiToken {get; set;}
+
+        /// <summary>
+        /// [optional] Extra HTTP headers to include on every request
+        /// </summary>
+        Dictionary<string, string> ExtraHeaders {get; set;}
 
         /// <summary>
         /// [optional] Jenkins CSRF Crumb.

--- a/Jenkins.Net/Internal/Commands/ArtifactGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/ArtifactGetCommand.cs
@@ -26,6 +26,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "artifact", urlFilename);
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/BuildGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/BuildGetCommand.cs
@@ -22,6 +22,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "api/xml");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/BuildOutputCommand.cs
+++ b/Jenkins.Net/Internal/Commands/BuildOutputCommand.cs
@@ -23,6 +23,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "consoleText");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnRead = response => {

--- a/Jenkins.Net/Internal/Commands/BuildProgressiveHtmlCommand.cs
+++ b/Jenkins.Net/Internal/Commands/BuildProgressiveHtmlCommand.cs
@@ -24,6 +24,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "logText/progressiveHtml");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/BuildProgressiveTextCommand.cs
+++ b/Jenkins.Net/Internal/Commands/BuildProgressiveTextCommand.cs
@@ -24,6 +24,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "logText/progressiveText");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/CrumbGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/CrumbGetCommand.cs
@@ -17,6 +17,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "crumbIssuer/api/xml");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
 
             OnWrite = request => {
                 request.Method = "GET";

--- a/Jenkins.Net/Internal/Commands/JenkinsGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JenkinsGetCommand.cs
@@ -17,6 +17,7 @@ namespace JenkinsNET.Internal.Commands
 
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobBuildCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobBuildCommand.cs
@@ -18,6 +18,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, "build?delay=0sec");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobCreateCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobCreateCommand.cs
@@ -21,6 +21,7 @@ namespace JenkinsNET.Internal.Commands
 
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobDeleteCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobDeleteCommand.cs
@@ -15,6 +15,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "job", jobName, "doDelete");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobGetCommand.cs
@@ -20,6 +20,7 @@ namespace JenkinsNET.Internal.Commands
 
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobGetConfigCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobGetConfigCommand.cs
@@ -24,6 +24,7 @@ namespace JenkinsNET.Internal.Commands
 
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/JobUpdateConfigurationCommand.cs
+++ b/Jenkins.Net/Internal/Commands/JobUpdateConfigurationCommand.cs
@@ -20,6 +20,7 @@ namespace JenkinsNET.Internal.Commands
 
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/QueueGetItemCommand.cs
+++ b/Jenkins.Net/Internal/Commands/QueueGetItemCommand.cs
@@ -17,6 +17,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "queue/item", itemNumber.ToString(), "api/xml");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/Commands/QueueItemListCommand.cs
+++ b/Jenkins.Net/Internal/Commands/QueueItemListCommand.cs
@@ -19,6 +19,7 @@ namespace JenkinsNET.Internal.Commands
             Url = NetPath.Combine(context.BaseUrl, "queue/api/xml");
             UserName = context.UserName;
             Password = context.Password;
+            ExtraHeaders = context.ExtraHeaders;
             Crumb = context.Crumb;
 
             OnWrite = request => {

--- a/Jenkins.Net/Internal/JenkinsHttpCommand.cs
+++ b/Jenkins.Net/Internal/JenkinsHttpCommand.cs
@@ -1,5 +1,6 @@
 ﻿using JenkinsNET.Models;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -19,6 +20,7 @@ namespace JenkinsNET.Internal
         public string Url {get; set;}
         public string UserName {get; set;}
         public string Password {get; set;}
+        public Dictionary<string, string> ExtraHeaders {get; set;}
         public JenkinsCrumb Crumb {get; set;}
         public Action<HttpWebRequest> OnWrite {get; set;}
         public Action<HttpWebResponse> OnRead {get; set;}
@@ -66,6 +68,10 @@ namespace JenkinsNET.Internal
             request.UserAgent = "Jenkins.NET Client";
             request.AllowAutoRedirect = true;
             request.KeepAlive = true;
+
+            if (ExtraHeaders != null)
+                foreach (var (key, value) in ExtraHeaders)
+                    request.Headers.Add(key, value);
 
             if (Crumb != null)
                 request.Headers.Add(Crumb.CrumbRequestField, Crumb.Crumb);

--- a/Jenkins.Net/Internal/JenkinsHttpCommand.cs
+++ b/Jenkins.Net/Internal/JenkinsHttpCommand.cs
@@ -70,8 +70,8 @@ namespace JenkinsNET.Internal
             request.KeepAlive = true;
 
             if (ExtraHeaders != null)
-                foreach (var (key, value) in ExtraHeaders)
-                    request.Headers.Add(key, value);
+                foreach (var header in ExtraHeaders)
+                    request.Headers.Add(header.Key, header.Value);
 
             if (Crumb != null)
                 request.Headers.Add(Crumb.CrumbRequestField, Crumb.Crumb);

--- a/Jenkins.Net/JenkinsClient.cs
+++ b/Jenkins.Net/JenkinsClient.cs
@@ -2,6 +2,7 @@
 using JenkinsNET.Internal.Commands;
 using JenkinsNET.Models;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +28,11 @@ namespace JenkinsNET
         /// [optional] Jenkins ApiToken for the <see cref="UserName"/>.
         /// </summary>
         public string ApiToken {get; set;}
+
+        /// <summary>
+        /// [optional] Extra HTTP headers to include on every request
+        /// </summary>
+        public Dictionary<string, string> ExtraHeaders {get; set;}
 
         /// <summary>
         /// Gets or sets the security Crumb to use on API requests.
@@ -90,6 +96,7 @@ namespace JenkinsNET
             this.UserName = context.UserName;
             this.ApiToken = context.ApiToken;
             this.Password = context.Password;
+            this.ExtraHeaders = context.ExtraHeaders;
             this.Crumb = context.Crumb;
         }
 


### PR DESCRIPTION
Hey, I have a situation where I want to include a nonstandard HTTP header on Jenkins requests which authorize them to get past a firewalling proxy.

I didn't see a way to attach custom headers using this library so I added an extension point in this PR to accept arbitrary key/value pairs at the JenkinsClient level.

I'm not sure if there's a decent way to test this, as it seems the tests assume a localhost Jenkins, and Rider isn't hooking up to xUnit for me to begin with. Perhaps the best way to test this change would be manually constructing and passing an `Authorization` header instead of passing `Username` and `ApiToken` (so, `Authorization: Basic Z3Vlc3Q6YmNiOTU0YTc3YWI0Nzc1MDIwMWE5ZjE4OGIxYjI1ZTg=`)
Indeed, this PR offers a superset of the Username/ApiToken functionality.

---

A possible different approach could be allowing a global OnWrite callback. Even more flexible but also easier to go wrong