### PR TITLE
Add  Support for Jenkins Folder Jobs

### DIFF
--- a/Jenkins.Net/Internal/Commands/ArtifactGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/ArtifactGetCommand.cs
@@ -23,7 +23,9 @@ namespace JenkinsNET.Internal.Commands
                 throw new ArgumentException("'filename' cannot be empty!");
 
             var urlFilename = filename.Replace('\\', '/');
-            Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "artifact", urlFilename);
+            var postfix = $"artifact/{urlFilename}";
+
+            Url = ConstructUrl(context.BaseUrl, jobName, buildNumber, postfix);
             UserName = context.UserName;
             Password = context.Password;
             Crumb = context.Crumb;

--- a/Jenkins.Net/Internal/Commands/BuildGetCommand.cs
+++ b/Jenkins.Net/Internal/Commands/BuildGetCommand.cs
@@ -19,7 +19,7 @@ namespace JenkinsNET.Internal.Commands
             if (string.IsNullOrEmpty(buildNumber))
                 throw new ArgumentException("'buildNumber' cannot be empty!");
 
-            Url = NetPath.Combine(context.BaseUrl, "job", jobName, buildNumber, "api/xml");
+            Url = ConstructUrl(context.BaseUrl, jobName, buildNumber, "api/xml");
             UserName = context.UserName;
             Password = context.Password;
             Crumb = context.Crumb;

--- a/Jenkins.Net/Internal/JenkinsHttpCommand.cs
+++ b/Jenkins.Net/Internal/JenkinsHttpCommand.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
+using System.Collections.Generic;
+
 
 #if NET_ASYNC
 using System.Threading;
@@ -154,5 +156,24 @@ namespace JenkinsNET.Internal
             const string pattern = @"<\?xml[^\>]*\?>";
             return Regex.Replace(xml, pattern, string.Empty);
         }
+
+        internal string ConstructUrl(string baseUrl, string jobName, string buildNumber,string postfix)
+        {
+            var jobParts = jobName.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
+            var urlParts = new List<string> { baseUrl };
+
+            foreach (var part in jobParts)
+            {
+                urlParts.Add("job");
+                urlParts.Add(part);
+            }
+
+            urlParts.Add(buildNumber);
+            urlParts.Add(postfix);
+
+            return NetPath.Combine(urlParts.ToArray());
+        }
+
+
     }
 }


### PR DESCRIPTION
Jenkins users often organize jobs within folders for better structure and scalability. Without folder support, interacting with such jobs via Jenkins.NET was limited or required workarounds. This feature allows users to work with foldered jobs.

Notes
- No breaking changes introduced.
- Tested against Jenkins with folder structure in place.

